### PR TITLE
Passive controller shows 'null' status. I guess its normal.

### DIFF
--- a/check_freenas.py
+++ b/check_freenas.py
@@ -71,7 +71,7 @@ class Startup(object):
         msg=''
         try:
             for repl in repls:
-                if repl['repl_status'] != 'Succeeded':
+                if repl['repl_status'] != 'Succeeded' and repl['repl_status'] != None:
                     errors = errors + 1
                     msg = msg + repl['repl_zfs'] + ' ';
         except:


### PR DESCRIPTION
I have a dual controller system, and the passive head return `null` in `repl['repl_zfs']`. The [documentacion](http://api.freenas.org/resources/storage.html#replication) is not very specific, so a guess its cocidered normal.