### PR TITLE
This will cause it to only alert for un-acked issues

### DIFF
--- a/check_freenas.py
+++ b/check_freenas.py
@@ -92,6 +92,7 @@ class Startup(object):
         msg=''
         try:
             for alert in alerts:
+              if alert['dismissed'] == 'false':
                 if alert['level'] == 'CRIT':
                     crit = crit + 1
                     msg = msg + '- (C) ' + string.replace(alert['message'], '\n', '. ') + ' '

--- a/freenas-icinga2.conf
+++ b/freenas-icinga2.conf
@@ -1,0 +1,16 @@
+object CheckCommand "freenas" {
+         import "plugin-check-command"
+
+         command = [ PluginDir + "/check_freenas" ]
+
+         arguments = {
+                 "-H" = "$freenas_host$"
+                 "-u" = "$freenas_user$"
+                 "-p" = "$freenas_password$"
+		 "-t" = "$freenas_type$"
+         }
+
+         vars.freenas_host = "$address$"
+         vars.freenas_user = "root"
+         vars.freenas_type = "alerts"
+}


### PR DESCRIPTION
If you uncheck an alert in freenas, this will cause it to reflect that status accordingly. I had a malfunctioning SMART check that I wanted to deal with later (but didn't want to have an alert for so I could catch any new errors), this accomodates that. :smile: 